### PR TITLE
added func element(equalTo element:Element) -> Element?

### DIFF
--- a/Sources/OrderedSet+Array.swift
+++ b/Sources/OrderedSet+Array.swift
@@ -28,12 +28,14 @@ extension OrderedSet : ArrayLiteralConvertible, RangeReplaceableCollectionType {
     public mutating func replaceRange<C : CollectionType where C.Generator.Element == IndexingGenerator<OrderedSet>.Element>(subRange: Range<Index>, with newElements: C) {
         let oldArray = array[subRange]
         let oldSet = Set(oldArray)
-        let (newArray, newSet) = collapse(newElements)
+        var (newArray, newSet) = collapse(newElements)
         let deletions = oldSet.subtract(newSet)
         set.subtractInPlace(deletions)
+        newArray = newArray.filter { (element) -> Bool in
+            return !set.contains(element)
+        }
         set.unionInPlace(newSet)
         array.replaceRange(subRange, with: newArray)
-        array = array.enumerate().filter { (index, element) in return subRange.contains(index) || subRange.startIndex == index || !newSet.contains(element) }.map { $0.element }
     }
 
     public var capacity: Int {

--- a/Sources/OrderedSet+Set.swift
+++ b/Sources/OrderedSet+Set.swift
@@ -20,6 +20,14 @@ extension OrderedSet {
         return set.contains(member)
     }
     
+    /// Returns Element equal to input one
+    public func element(equalTo element:Element) -> Element? {
+        if let indexOfElement = set.indexOf(element) {
+            return set[indexOfElement]
+        }
+        return nil
+    }
+    
     /// Remove the member from the ordered set and return it if it was present.
     public mutating func remove(member: Element) -> Element? {
         guard let index = array.indexOf(member) else { return nil }

--- a/Tests/OrderedSetTests.swift
+++ b/Tests/OrderedSetTests.swift
@@ -37,6 +37,12 @@ class OrderedSetTests: XCTestCase {
         XCTAssert(orderedSet == ["Brad", "Lorraine", "Natalie", "Sarah", "Scott"])
     }
     
+    func testElementEqualTo() {
+        let orderedSet: OrderedSet<String> = ["Brad", "Lorraine", "Brad", "Sarah"]
+        XCTAssertNotNil(orderedSet.element(equalTo: "Lorraine"))
+        XCTAssertNil(orderedSet.element(equalTo: "Aleksei"))
+    }
+    
 }
 
 func ==(lhs: OrderedSet<String>, rhs: Array<String>) -> Bool {

--- a/Tests/OrderedSetTests.swift
+++ b/Tests/OrderedSetTests.swift
@@ -43,6 +43,18 @@ class OrderedSetTests: XCTestCase {
         XCTAssertNil(orderedSet.element(equalTo: "Aleksei"))
     }
     
+    func testOrderPreservance() {
+        var orderedSet1: OrderedSet<Int> = [3,2,1]
+        let orderedSet2: OrderedSet<Int> = [3,5,1]
+        
+        orderedSet1.unionInPlace(orderedSet2)
+        
+        print("orderedSet1.array: ", orderedSet1.array)
+        
+        XCTAssert(orderedSet1.array == [3,2,1,5])
+        
+        
+    }
 }
 
 func ==(lhs: OrderedSet<String>, rhs: Array<String>) -> Bool {


### PR DESCRIPTION
Hi!

I offer you to extend functionality of OrderedSet with function **element(equalTo:) -> Element?**
It gives developers O(1) complexity access to required elements in the OrderedSet.

Also I changed replaceRange function to keep the order of internal array
